### PR TITLE
Copy to system bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ staticcheck:
 .PHONY: install
 install:
 		@echo "+ $@"
-		@cp $(BUILD_DIR)/* $(GOPATH)/bin
+		@cp $(BUILD_DIR)/* /usr/local/bin
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Similar to #33, this probably weds the Makefile to a specific system. What are the conventions around this?

There isn't a `bin` in `$GOPATH` for me... I could probably just create it, but not sure what the best practice is